### PR TITLE
Bootstrap android app with native code and ci

### DIFF
--- a/.github/workflows/build-shim.yml
+++ b/.github/workflows/build-shim.yml
@@ -1,0 +1,27 @@
+name: build-argus-shim
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  shim:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Build shim
+        uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: 8.8
+          arguments: build
+          build-root-directory: shim/argus_input_shim_fabric
+      - name: Upload JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: argus-input-shim-jar
+          path: shim/argus_input_shim_fabric/build/libs/*.jar

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,20 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    maven("https://maven.fabricmc.net/")
+    mavenCentral()
+    google()
+  }
+}
+
+dependencyResolutionManagement {
+  repositories {
+    mavenCentral()
+    maven("https://maven.fabricmc.net/")
+    google()
+  }
+}
+
+rootProject.name = "argus-java-monorepo"
+
+include(":shim:argus_input_shim_fabric")

--- a/shim/argus_input_shim_fabric/build.gradle.kts
+++ b/shim/argus_input_shim_fabric/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+  id("fabric-loom") version "1.6-SNAPSHOT"
+  java
+}
+
+group = "com.argus"
+version = "0.0.2-alpha"
+
+repositories {
+  mavenCentral()
+  maven("https://maven.fabricmc.net/")
+}
+
+dependencies {
+  minecraft("com.mojang:minecraft:1.20.1")
+  mappings("net.fabricmc:yarn:1.20.1+build.10:v2")
+  modImplementation("net.fabricmc:fabric-loader:0.14.23")
+  modImplementation("net.fabricmc.fabric-api:fabric-api:0.90.4+1.20.1")
+}
+
+java {
+  toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+  withSourcesJar()
+}
+
+tasks.processResources {
+  inputs.property("version", version)
+  filesMatching("fabric.mod.json") {
+    expand(mapOf("version" to version))
+  }
+}

--- a/shim/argus_input_shim_fabric/src/main/c/jni_input_dequeue.c
+++ b/shim/argus_input_shim_fabric/src/main/c/jni_input_dequeue.c
@@ -1,0 +1,23 @@
+#include <jni.h>
+#include <string.h>
+#include <stdint.h>
+#include "argus_engine.h"       // must declare argus_engine_dequeue_input_c(...)
+#include "libargus_input.h"     // argus_input_event_t
+
+JNIEXPORT jint JNICALL
+Java_com_argus_input_ArgusNative_nativeDequeue(
+        JNIEnv* env, jclass clazz, jlong handle, jobject outBuf)
+{
+    (void)clazz;
+    argus_engine_t* eng = (argus_engine_t*)(uintptr_t)handle;
+    if (!eng || !outBuf) return 0;
+
+    void* dst = (*env)->GetDirectBufferAddress(env, outBuf);
+    if (!dst) return 0;
+
+    argus_input_event_t e;
+    if (!argus_engine_dequeue_input_c(eng, &e)) return 0;
+
+    memcpy(dst, &e, sizeof(e));   // struct is ~48–64 bytes
+    return 1;
+}

--- a/shim/argus_input_shim_fabric/src/main/java/com/argus/input/ArgusInputShim.java
+++ b/shim/argus_input_shim_fabric/src/main/java/com/argus/input/ArgusInputShim.java
@@ -1,0 +1,103 @@
+package com.argus.input;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Client mod that:
+ *  - Reads the Argus engine native handle from JVM property: -Dargus.handle=<long>
+ *  - Polls native input queue each tick
+ *  - Injects into MC client safely
+ *  - Draws a small "Argus" HUD button row (Skins/Marketplace/Close)
+ */
+public class ArgusInputShim implements ClientModInitializer {
+
+    // Mirror the C layout offsets (see your argus_input_event_t)
+    private static final int OFF_TYPE    =  8;      // int
+    private static final int OFF_X       = 16;      // float (x)
+    private static final int OFF_Y       = 20;      // float (y)
+    private static final int OFF_DX      = 24;      // float (dx)
+    private static final int OFF_DY      = 28;      // float (dy)
+    private static final int OFF_BTN     = 32;      // int (buttons)
+    private static final int OFF_KEY     = 40;      // int (keycode)
+    private static final int OFF_ACTION  = 44;      // byte (action)
+    private static final int OFF_MODS    = 45;      // byte (mods)
+
+    private static final int TYPE_MOTION = 1;
+    private static final int TYPE_KEY    = 3;
+
+    private static long ENGINE_HANDLE = 0L;
+    private static final ByteBuffer EVT = ArgusNative.newEventBuffer();
+
+    private static float sensitivity = 1.0f;
+
+    @Override
+    public void onInitializeClient() {
+        String prop = System.getProperty("argus.handle", "0");
+        try { ENGINE_HANDLE = Long.parseUnsignedLong(prop); } catch (Exception ignored) {}
+
+        // Pump events every client tick
+        ClientTickEvents.END_CLIENT_TICK.register(client -> {
+            if (ENGINE_HANDLE == 0) return;
+            while (ArgusNative.nativeDequeue(ENGINE_HANDLE, EVT) == 1) {
+                int type = EVT.getInt(OFF_TYPE);
+                if (type == TYPE_MOTION) {
+                    float dx = EVT.getFloat(OFF_DX);
+                    float dy = EVT.getFloat(OFF_DY);
+                    int buttons = EVT.getInt(OFF_BTN);
+                    ArgusMcBridge.injectMotion(dx, dy, buttons, sensitivity);
+                } else if (type == TYPE_KEY) {
+                    int key = EVT.getInt(OFF_KEY);
+                    int action = EVT.get(OFF_ACTION);
+                    int mods = EVT.get(OFF_MODS);
+                    ArgusMcBridge.injectKey(key, action, mods);
+                }
+                EVT.rewind();
+            }
+        });
+
+        // Minimal HUD (top bar)
+        HudRenderCallback.EVENT.register(ArgusInputShim::drawHud);
+    }
+
+    private static void drawHud(DrawContext ctx, float tickDelta){
+        var mc = MinecraftClient.getInstance();
+        if (mc.currentScreen != null) return;
+
+        int sw = ctx.getScaledWindowWidth();
+        int barH = 18;
+        ctx.fill(0, 0, sw, barH, 0xFF151515);
+        for (int y=0; y<barH; y+=2) ctx.fill(0, y, sw, y+1, 0x20111111);
+
+        // "X" close box
+        int x0 = sw-18, y0=2;
+        ctx.fill(x0, y0, x0+16, y0+16, 0xFF2B2B2B);
+        ctx.drawText(mc.textRenderer, "X", x0+5, y0+4, 0xFFE1E1E1, false);
+
+        // Buttons
+        ctx.fill(6, 3, 56, 15, 0xFF2B2B2B);
+        ctx.drawText(mc.textRenderer, "Skins", 12, 5, 0xFFFFFFFF, false);
+        ctx.fill(62, 3, 152, 15, 0xFF2B2B2B);
+        ctx.drawText(mc.textRenderer, "Marketplace", 68, 5, 0xFFFFFFFF, false);
+
+        // Click hitboxes – simple/safe
+        if (mc.mouse.wasLeftButtonClicked()){
+            int mx = (int)(mc.mouse.getX() / mc.getWindow().getScaleFactor());
+            int my = (int)(mc.mouse.getY() / mc.getWindow().getScaleFactor());
+            if (my >= 2 && my <= 18){
+                if (mx >= x0 && mx <= x0+16) {
+                    mc.scheduleStop();
+                } else if (mx >= 6 && mx <= 56) {
+                    mc.setScreen(new net.minecraft.client.gui.screen.message.SocialInteractionsScreen(mc));
+                } else if (mx >= 62 && mx <= 152) {
+                    mc.setScreen(new net.minecraft.client.gui.screen.advancement.AdvancementsScreen(mc.player.networkHandler.getAdvancementHandler()));
+                }
+            }
+        }
+    }
+}

--- a/shim/argus_input_shim_fabric/src/main/java/com/argus/input/ArgusMcBridge.java
+++ b/shim/argus_input_shim_fabric/src/main/java/com/argus/input/ArgusMcBridge.java
@@ -1,0 +1,45 @@
+package com.argus.input;
+
+import net.minecraft.client.MinecraftClient;
+
+/** Minimal, safe input injection helpers (1.20.1). */
+public final class ArgusMcBridge {
+    private ArgusMcBridge(){}
+
+    /** Mouse-look + basic mouse buttons. */
+    public static void injectMotion(float dx, float dy, int buttons, float sensitivity){
+        var mc = MinecraftClient.getInstance();
+        if (mc.player == null || mc.isPaused()) return;
+
+        var p = mc.player;
+        p.setYaw(p.getYaw() + dx * sensitivity * 0.15f);
+        float newPitch = p.getPitch() - dy * sensitivity * 0.15f;
+        if (newPitch > 90f) newPitch = 90f;
+        if (newPitch < -90f) newPitch = -90f;
+        p.setPitch(newPitch);
+
+        // Buttons: 1 = attack, 2 = use (bitfield)
+        if ((buttons & 1) != 0) mc.doAttack();
+        if ((buttons & 2) != 0) mc.doItemUse();
+    }
+
+    /** Discrete keys (jump, etc.). action: 1=down */
+    public static void injectKey(int keyCode, int action, int mods){
+        var mc = MinecraftClient.getInstance();
+        if (mc.player == null) return;
+
+        switch (keyCode){
+            case 32: // Space -> jump
+                if (action == 1) mc.player.jump();
+                break;
+            case 1001: // attack
+                if (action == 1) mc.doAttack();
+                break;
+            case 1002: // use
+                if (action == 1) mc.doItemUse();
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/shim/argus_input_shim_fabric/src/main/java/com/argus/input/ArgusNative.java
+++ b/shim/argus_input_shim_fabric/src/main/java/com/argus/input/ArgusNative.java
@@ -1,0 +1,17 @@
+package com.argus.input;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public final class ArgusNative {
+    // The native library is loaded by your Android launcher process.
+    // The mod only calls a native method exposed by that library.
+
+    /** Returns 1 if an event was dequeued and written into outBuf, else 0. */
+    public static native int nativeDequeue(long engineHandle, ByteBuffer outBuf);
+
+    /** Allocate a direct buffer big enough for the C struct (64 bytes). */
+    public static ByteBuffer newEventBuffer() {
+        return ByteBuffer.allocateDirect(64).order(ByteOrder.nativeOrder());
+    }
+}

--- a/shim/argus_input_shim_fabric/src/main/resources/fabric.mod.json
+++ b/shim/argus_input_shim_fabric/src/main/resources/fabric.mod.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "id": "argus_input_shim",
+  "version": "${version}",
+  "name": "Argus Input Shim",
+  "description": "Polls Argus native input queue over JNI and injects into Minecraft.",
+  "environment": "client",
+  "entrypoints": {
+    "client": [ "com.argus.input.ArgusInputShim" ]
+  },
+  "depends": {
+    "fabricloader": ">=0.14.21",
+    "minecraft": ">=1.20",
+    "fabric-api": "*"
+  },
+  "license": "LGPL-3.0",
+  "contact": {
+    "sources": "https://github.com/your-username/Argus-java-mobile-mc"
+  }
+}


### PR DESCRIPTION
Add Fabric/Quilt input shim module and JNI bridge for Minecraft integration.

This enables the Argus native engine to inject input into Minecraft, completing the "playable alpha shell" for v0.0.1-alpha. The shim module polls the native input queue via JNI and injects motion and key events into the Minecraft client, allowing for touch controls from the Android launcher to control the game. A CI workflow is also added to build and upload the shim JAR.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2d78be1-a9b1-40be-9f5e-5a13580d27cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2d78be1-a9b1-40be-9f5e-5a13580d27cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

